### PR TITLE
Moving meme commands to new file meme.ts

### DIFF
--- a/commands/general.ts
+++ b/commands/general.ts
@@ -1,10 +1,3 @@
-const ngo = () => {
-	return `:middle_finger: 
-:no_entry_sign: :no_entry_sign: :no_entry_sign:
-NO COINERS GET OUT
-:poop: :poop: :poop:
-:thumbsdown:`
-}
 const help = () => {
 	const helpObj = {
 		'.cmc': {
@@ -15,8 +8,12 @@ const help = () => {
 		},
 		'.gen': {
 			h: 'help'
+		},
+		'.meme': {
+			n: 'ngo',
+			s: 'spec'
 		}
 	}
 	return helpObj
 }
-export default { ngo, help }
+export default { help }

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -1,7 +1,8 @@
 import cmc from './cmc'
 import gen from './general'
+import meme from './meme'
 
-const commandObj = { cmc, gen }
+const commandObj = { cmc, gen, meme }
 const PREFIX = '.'
 
 const preFixedCommandObj = Object.keys(

--- a/commands/meme.ts
+++ b/commands/meme.ts
@@ -1,0 +1,17 @@
+const ngo = () => {
+	return `:middle_finger: 
+:no_entry_sign: :no_entry_sign: :no_entry_sign:
+NO COINERS GET OUT
+:poop: :poop: :poop:
+:thumbsdown:`
+}
+
+const spec = () => {
+	return `Warning!
+
+S P E C U L A T I O N
+
+Warning!`
+}
+
+export default { ngo, n: ngo, spec, s: spec}


### PR DESCRIPTION
Memes should be segregated from actual functionality as they require tremendous amounts of upkeep to stay dank.

This will allow for easier additions to dank meme commands and will organize the repository in a better fashion.